### PR TITLE
Avoid warning message when execute git pull command

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -132,7 +132,7 @@ namespace :rsync do
           pull << "--depth=#{fetch(:rsync_depth)}"
         end
         pull << "origin"
-        pull << rsync_target.call
+        pull << fetch(:branch)
         Kernel.system *pull
       end
     else


### PR DESCRIPTION
Avoir error message due to the execution of a command like "git pull origin origin/branchName" :

```
** Execute rsync:stage
fatal: ambiguous argument 'develop': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
** Invoke deploy:precompile (first_time)
** Execute deploy:precompile
```
