### PR TITLE
Change on format for Capistrano v3.4+ support

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -169,7 +169,9 @@ namespace :rsync do
     next if !has_roles?
 
     copy = %(#{fetch(:rsync_copy)} "#{rsync_cache.call}/" "#{release_path}/")
-    on roles(:all).each do execute copy end
+    on roles(:all) do |host|
+      execute copy
+    end
   end
 
   # Matches the naming scheme of git tasks.


### PR DESCRIPTION
Hi,

This is a minor change to support Capistrano v3.4. Details of the error are in moll/capistrano-rsync/issues/23

Credit for this fix goes to @wwhurley via forumone/web-starter/issues/59
