### PR TITLE
Avoid the double launch of the commands due to require in addition to scm

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ Install with:
 gem install capistrano-rsync-bladrak
 ```
 
-Require it at the top of your `Capfile` (or `config/deploy.rb`):
-```ruby
-require "capistrano/rsync"
+Set rsync as the SCM to use
+```
+set :scm, :rsync
 ```
 
 Set some `rsync_options` to your liking:
@@ -96,6 +96,23 @@ after "rsync:stage", "precompile"
 ### Deploy release without symlinking the current directory
 ```
 cap rsync:release
+```
+
+Troubleshooting
+---------------
+If you need to hook after rsync:stage in your deploy.rb, the rsync namespace is not loaded yet.
+
+So do it like this in your deploy.rb:
+```
+namespace :rsync do
+    # Create an empty task to hook with. Implementation will be come next
+    task :stage
+
+    # Then add your hook
+    after :stage, :my_task do
+      # Do some stuff.
+    end
+end
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ set :rsync_options, %w[
 ```
 
 ### Precompile assets before deploy
-Capistrano::Rsync runs `rsync:stage` before rsyncing. Hook to that like this:
+Capistrano::Rsync runs `rsync:stage_done` before rsyncing. Hook to that like this:
 ```ruby
 task :precompile do
   Dir.chdir fetch(:rsync_stage) do
@@ -90,7 +90,7 @@ task :precompile do
   end
 end
 
-after "rsync:stage", "precompile"
+after "rsync:stage_done", "precompile"
 ```
 
 ### Deploy release without symlinking the current directory
@@ -100,16 +100,16 @@ cap rsync:release
 
 Troubleshooting
 ---------------
-If you need to hook after rsync:stage in your deploy.rb, the rsync namespace is not loaded yet.
+If you need to hook after rsync:stage_done in your deploy.rb, the rsync namespace is not loaded yet.
 
 So do it like this in your deploy.rb:
 ```
 namespace :rsync do
     # Create an empty task to hook with. Implementation will be come next
-    task :stage
+    task :stage_done
 
     # Then add your hook
-    after :stage, :my_task do
+    after :stage_done, :my_task do
       # Do some stuff.
     end
 end

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -1,31 +1,25 @@
 require File.expand_path("../rsync/version", __FILE__)
 
-namespace :load do
-  task :defaults do
+set_if_empty :rsync_options, []
+set_if_empty :rsync_copy, "rsync --archive --acls --xattrs"
 
-    set :rsync_options, []
-    set :rsync_copy, "rsync --archive --acls --xattrs"
+# Sparse checkout allows to checkout only part of the repository
+set_if_empty :rsync_sparse_checkout, []
 
-    # Sparse checkout allows to checkout only part of the repository
-    set :rsync_sparse_checkout, []
+# You may not need the whole history, put to false to get it whole
+set_if_empty :rsync_depth, 1
 
-    # You may not need the whole history, put to false to get it whole
-    set :rsync_depth, 1
+# Stage is used on your local machine for rsyncing from.
+set_if_empty :rsync_stage, "tmp/deploy"
 
-    # Stage is used on your local machine for rsyncing from.
-    set :rsync_stage, "tmp/deploy"
+# Cache is used on the server to copy files to from to the release directory.
+# Saves you rsyncing your whole app folder each time.  If you nil rsync_cache,
+# Capistrano::Rsync will sync straight to the release path.
+set_if_empty :rsync_cache, "shared/deploy"
 
-    # Cache is used on the server to copy files to from to the release directory.
-    # Saves you rsyncing your whole app folder each time.  If you nil rsync_cache,
-    # Capistrano::Rsync will sync straight to the release path.
-    set :rsync_cache, "shared/deploy"
+set_if_empty :rsync_target_dir, ""
 
-    set :rsync_target_dir, ""
-
-    set :enable_git_submodules, false
-  end
-end
-
+set_if_empty :enable_git_submodules, false
 
 # NOTE: Please don't depend on tasks without a description (`desc`) as they
 # might change between minor or patch version releases. They make up the
@@ -55,6 +49,7 @@ task :rsync => %w[rsync:stage] do
     rsync << File.join(fetch(:rsync_stage), File.join(fetch(:rsync_target_dir), ""))
     rsync << "#{user}#{role.hostname}:#{rsync_cache.call || release_path}"
 
+    puts *rsync
     Kernel.system *rsync
   end
 end
@@ -163,8 +158,8 @@ namespace :rsync do
       Kernel.system *update
 
       if fetch(:enable_git_submodules)
-	submodules = %W[git submodule update]
-	Kernel.system *submodules
+        submodules = %W[git submodule update]
+        Kernel.system *submodules
       end
 
       checkout = %W[git reset --quiet --hard #{rsync_target.call}]

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -40,7 +40,7 @@ end
 Rake::Task["deploy:check"].enhance ["rsync:hook_scm"]
 
 desc "Stage and rsync to the server (or its cache)."
-task :rsync => %w[rsync:stage] do
+task :rsync => %w[rsync:stage_done] do
   on release_roles(:all) do |role|
     user = role.user + "@" if !role.user.nil?
 
@@ -166,6 +166,8 @@ namespace :rsync do
       Kernel.system *checkout
     end
   end
+
+  task :stage_done => %w[stage]
 
   desc "Copy the code to the releases directory."
   task :release => %w[rsync] do


### PR DESCRIPTION
To avoid the double launch of commands, and set this up like any other scm, I propose to:
- remove the require from Capfile / deploy.rb
- use set_if_empty for default values to avoid values overriding (since no more launch of load:defaults in this mode)
- add in the documentation a workaround for the existence of the rsync:stage task when parsing deploly.rb (using an empty task).

This solved the problem for me. Don't hesitate to comment of course.
