### PR TITLE
git <1.9 needs fetch tags to be done on its own

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -158,8 +158,11 @@ namespace :rsync do
 
     run_locally do
       within fetch(:rsync_stage) do
-        tags = !!fetch(:rsync_checkout_tag, false) ? '--tags' : ''
-        execute :git, :fetch, '--quiet --all --prune', "#{tags}", "#{git_depth.call}"
+        execute :git, :fetch, '--quiet --all --prune', "#{git_depth.call}"
+
+        if !!fetch(:rsync_checkout_tag, false)
+          execute :git, :fetch, '--quiet --tags'
+        end
 
         execute :git, :reset, '--quiet', '--hard', "#{rsync_target.call}"
 


### PR DESCRIPTION
and since git is still in 1.7 on some system like Debian wheezy still used by some people, we need to split the calls.

Note: this only affects tags modified after creation, not new tags...
