### PR TITLE
Add a reset of all submodules to avoid update issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ rsync_checkout_tag  | `false` | Is the ``:branch`` symbol containing a branch or
 rsync_copy    | `rsync --archive --acls --xattrs` | The command used to copy from remote cache to remote release
 rsync_target_dir | `.` | The local directory within ``:rsync_stage`` to clone to & deploy (useful if you want to keep cache of several branches/tags for instance)
 enable_git_submodules | `false` | Should we fetch submodules as well?
+reset_git_submodules_before_update | `false` | Do a reset hard on submodules (in case you do modifications on working copies)?
 
 
 License

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -26,6 +26,8 @@ set_if_empty :rsync_target_dir, "."
 
 set_if_empty :enable_git_submodules, false
 
+set_if_empty :reset_git_submodules_before_update, false
+
 # NOTE: Please don't depend on tasks without a description (`desc`) as they
 # might change between minor or patch version releases. They make up the
 # private API and internals of Capistrano::Rsync. If you think something should
@@ -167,7 +169,9 @@ namespace :rsync do
         execute :git, :reset, '--quiet', '--hard', "#{rsync_target.call}"
 
         if fetch(:enable_git_submodules)
-          execute :git, :submodule, :foreach, "git reset --hard HEAD"
+          if fetch(:reset_git_submodules_before_update)
+            execute :git, :submodule, :foreach, "git reset --hard HEAD"
+          end
 
           execute :git, :submodule, :update
         end

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -167,6 +167,8 @@ namespace :rsync do
         execute :git, :reset, '--quiet', '--hard', "#{rsync_target.call}"
 
         if fetch(:enable_git_submodules)
+          execute :git, :submodule, :foreach, "git reset --hard HEAD"
+
           execute :git, :submodule, :update
         end
       end


### PR DESCRIPTION
To avoid issues when updating submodules with uncommitted changes, I propose to add a git reset --hard on all submodules before updating.
