### PR TITLE
Added clean submodule directory.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.3.5 (Sep 7, 2015)
+- Adds clean command to submodules to remove untracking files.
+- Rectifies the tag deployment.
+
 ## 1.3.4 (Jul 17, 2015)
 - Added ``:git_remote`` option. Gives the opportunity to define some other remote that ``origin``.
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ rsync_checkout_tag  | `false` | Is the ``:branch`` symbol containing a branch or
 rsync_copy    | `rsync --archive --acls --xattrs` | The command used to copy from remote cache to remote release
 rsync_target_dir | `.` | The local directory within ``:rsync_stage`` to clone to & deploy (useful if you want to keep cache of several branches/tags for instance)
 enable_git_submodules | `false` | Should we fetch submodules as well?
-reset_git_submodules_before_update | `false` | Do a reset hard on submodules (in case you do modifications on working copies)?
+reset_git_submodules_before_update | `false` | Do a reset hard and clean force on submodules (in case you do modifications on working copies)?
 
 
 License

--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -193,7 +193,7 @@ namespace :rsync do
 
         if fetch(:enable_git_submodules)
           if fetch(:reset_git_submodules_before_update)
-            execute :git, :submodule, :foreach, "git reset --hard HEAD"
+            execute :git, :submodule, :foreach, "'git reset --hard HEAD && git clean -qfd'"
           end
 
           execute :git, :submodule, :update

--- a/lib/capistrano/rsync/version.rb
+++ b/lib/capistrano/rsync/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Rsync
-    VERSION = "1.3.4"
+    VERSION = "1.3.5"
   end
 end


### PR DESCRIPTION
When using _reset_git_submodules_before_update_ variable at true, we reset the tracking files from git, but not the untracking files.
In our case, we generate assets and want to clean them before next deploy.
