### PR TITLE
Don't return nil if revision is already clean

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -113,7 +113,7 @@ namespace :rsync do
 
     run_locally do
       within fetch(:rsync_stage) do
-        rev = capture(:git, 'rev-parse', 'HEAD').strip!
+        rev = capture(:git, 'rev-parse', 'HEAD').strip
         set :current_revision, rev
       end
     end


### PR DESCRIPTION
I had a case when the revision string did not included any whitespace (maybe after an upgrade of a dependency).
And this happened to break the current_revision variable because strip! returned nil instead of the value without space (= the value itself in my case).
