### PR TITLE
Add fetch -t for submodules

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -188,7 +188,7 @@ namespace :rsync do
 
         if fetch(:enable_git_submodules)
           if fetch(:reset_git_submodules_before_update)
-            execute :git, :submodule, :foreach, "'git reset --hard HEAD && git clean -qfd'"
+            execute :git, :submodule, :foreach, "'git reset --hard HEAD && git clean -qfd && git fetch -t'"
           end
 
           execute :git, :submodule, :update


### PR DESCRIPTION
Like https://github.com/Bladrak/capistrano-rsync/pull/10, I need to fetch all the tags for each submodule.

With git fetch -t in the git submodule foreach, it is working ;).
