### PR TITLE
Precompile example should raise an error on build failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Capistrano::Rsync runs `rsync:stage_done` before rsyncing. Hook to that like thi
 ```ruby
 task :precompile do
   Dir.chdir fetch(:rsync_stage) do
-    system "rake", "assets:precompile"
+    system "rake", "assets:precompile" or raise
   end
 end
 


### PR DESCRIPTION
I think is useful to terminate the cap deployment if some errors occurred in the local build step.

Please note: I am not a ruby developer and googled my way to this solution.
