### PR TITLE
Fix rsync failures with several targets

### DIFF
--- a/lib/capistrano/rsync.rb
+++ b/lib/capistrano/rsync.rb
@@ -84,7 +84,7 @@ Rake::Task["deploy:check"].enhance ["rsync:hook_scm"]
 # Local -> Remote cache
 desc "Stage and rsync to the server (or its cache)."
 task :rsync => %w[rsync:stage_done] do
-  on release_roles(:all) do |role|
+  release_roles(:all).each do |role|
     user = role.user + "@" if !role.user.nil?
     rsync_options = fetch(:rsync_options)
 


### PR DESCRIPTION
Hello

I encountered an issue with a project installed on 3 servers. With the function "on", the rsync to the remote cache always fails:

```sh
00:02 rsync
      01 rsync -e 'ssh -p 225' -e 'ssh -p 222' --recursive --delete --delete-excluded --exclude .git* --exclude .arc* . user…
      01 file has vanished: "/home/user/project/shared/deploy/some-file…
      01 file has vanished: "/home/user/project/shared/deploy/another-file…
    ✔ 01 user@localhost 4.263s
      01 rsync warning: some files vanished before they could be transferred (code 24) at main.c(1183) [sender=3.1.0]
```

Without the "on" function, iterating over the roles just work:

```sh
00:02 rsync
      01 rsync -e 'ssh -p 222' --recursive --delete --delete-excluded --exclude .git* --exclude .arc* . user@server…
    ✔ 01 user@localhost 2.993s
      02 rsync -e 'ssh -p 225' -e 'ssh -p 222' --recursive --delete --delete-excluded --exclude .git* --exclude .arc* . us…
    ✔ 02 kraken@localhost 3.427s
      03 rsync -e 'ssh -p 222' -e 'ssh -p 225' -e 'ssh -p 222' --recursive --delete --delete-excluded --exclude .git* --ex…
    ✔ 03 kraken@localhost 3.290s
      04 rsync -e 'ssh -p 225' -e 'ssh -p 222' -e 'ssh -p 225' -e 'ssh -p 222' --recursive --delete --delete-excluded --ex…
```

As you can see, the command is built and built again and each time an option "-e 'ssh -p #{port}'" is appended... but it's work.

My stage look like this:

```ruby
server 'some-ip', port: 222, user: 'user', roles: %w{app nginx}
server 'another-ip', port: 225, user: 'user', roles: %w{app apache}
```
